### PR TITLE
Add Ungoogled Chromium specific icon to avoid trademark issues

### DIFF
--- a/build-aux/install.sh
+++ b/build-aux/install.sh
@@ -14,8 +14,9 @@ popd
 install -Dm 755 out/ReleaseFree/libffmpeg.so /app/chromium/libffmpeg.so
 install -Dm 755 out/Release/libffmpeg.so /app/chromium/nonfree-codecs/lib/libffmpeg.so
 for size in 24 48 64 128 256; do
-	install -Dvm 644 "chrome/app/theme/chromium/linux/product_logo_${size}.png" "/app/share/icons/hicolor/${size}x${size}/apps/io.github.ungoogled_software.ungoogled_chromium.png";
+	install -Dvm 644 "/app/ugc/icons/logo_${size}.png" "/app/share/icons/hicolor/${size}x${size}/apps/io.github.ungoogled_software.ungoogled_chromium.png";
 done
+install -Dvm 644 /app/ugc/icons/logo.svg /app/share/icons/hicolor/scalable/apps/io.github.ungoogled_software.ungoogled_chromium.svg
 install -Dvm 644 cobalt.ini -t /app/etc
 install -Dvm 644 /app/ugc/io.github.ungoogled_software.ungoogled_chromium.desktop -t /app/share/applications
 install -Dvm 644 /app/ugc/io.github.ungoogled_software.ungoogled_chromium.metainfo.xml -t /app/share/metainfo

--- a/io.github.ungoogled_software.ungoogled_chromium.yaml
+++ b/io.github.ungoogled_software.ungoogled_chromium.yaml
@@ -117,8 +117,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ungoogled-software/ungoogled-chromium-flatpak
-        tag: 125.0.6422.112-1
-        commit: 980bc2a1254fa0ec73e52fe49d4160aec4389d21
+        tag: 125.0.6422.112-2
+        commit: 29cc464fd67922a98aa9f9099b0758eb8d7b31f3
         x-checker-data:
           type: git
           tag-pattern: ^(\d+\.\d+\.\d+\.\d+-\d+)$


### PR DESCRIPTION
ungoogled-chromium is just a patchset and does not care about modifying icons, so these things should be distribution specific.

Ideally if others find they need to update the icon again, we might have to have some kind of concensus and put it in some contrib folder.