### PR TITLE
Set proper desktop filename for main window

### DIFF
--- a/chromium.sh
+++ b/chromium.sh
@@ -19,4 +19,5 @@ if [[ ! -f /app/chromium/extensions/no-mount-stamp ]]; then
   merge_extensions policies/recommended
 fi
 
+export CHROME_DESKTOP="io.github.ungoogled_software.ungoogled_chromium.desktop"
 exec cobalt "$@"


### PR DESCRIPTION
While attempting to fix
https://github.com/ungoogled-software/ungoogled-chromium-flatpak/issues/4, @bbhtt noted that the desktop filename was being set improperly which might be a source of icon issues but it is unclear whether it would fix the PIP window icon issue or not.