### PR TITLE
Disable the Google Hangouts extension

### DIFF
--- a/build-aux/bootstrap.sh
+++ b/build-aux/bootstrap.sh
@@ -39,7 +39,6 @@ cat >> out/Release/args.gn <<-EOF
 	use_vaapi=true
 	rtc_use_pipewire=true
 	rtc_link_pipewire=true
-	enable_hangout_services_extension=true
 	use_system_libwayland=false
 	use_system_libffi=true
 	use_qt=false


### PR DESCRIPTION
This extension never worked in the first place because `google.com` gets rewritten to `9oo91e.qjz9zk`. However, to avoid user confusion; we drop it from the build configuration.