### PR TITLE
Allow FIDO CTAP using “hybrid” transport via BLE by default

### DIFF
--- a/io.github.ungoogled_software.ungoogled_chromium.yaml
+++ b/io.github.ungoogled_software.ungoogled_chromium.yaml
@@ -15,6 +15,7 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland
+  - --allow=bluetooth # FIDO2 CTAP hybrid transport
   - --system-talk-name=org.bluez
   - --system-talk-name=org.freedesktop.Avahi
   - --system-talk-name=org.freedesktop.UPower


### PR DESCRIPTION
The hybrid transport authenticator type allows cross-platform authentication via FIDO Client-to-Authenticator Protocol (CTAP). E.g. signing in with passkeys from a smartphone via bluetooth on a desktop computer, by connecting via a QR code.

Chromium as a Flatpak does not show the devices option in FIDO2 authentication dialog until it detects Bluetooth. Hence allow bluetooth feature by default to enable seamless passkey usage with ungoogled Chromium.