### PR TITLE
Compress locales to reduce install size

### DIFF
--- a/build-aux/build.sh
+++ b/build-aux/build.sh
@@ -23,8 +23,8 @@ export NM=nm
 # https://github.com/ungoogled-software/ungoogled-chromium/pull/2696#issuecomment-1918173198
 export RUSTC_BOOTSTRAP=1
 
-# Initialize our own compiler flags
-export CFLAGS='' CXXFLAGS=''
+# Initialize our own compiler flags and disable the SDK's defaults
+export CFLAGS='' CXXFLAGS='' CPPFLAGS=''
 unset LDFLAGS RUSTFLAGS
 
 # Facilitate deterministic builds (taken from build/config/compiler/BUILD.gn)

--- a/build-aux/install.sh
+++ b/build-aux/install.sh
@@ -3,19 +3,37 @@ set -exo pipefail
 
 mkdir -p /app/chromium
 
-pushd out/Release
-for path in chrome chrome_crashpad_handler icudtl.dat *.so libvulkan.so.1 *.pak *.bin *.png locales MEIPreload vk_swiftshader_icd.json; do
-	# All the 'libVk*' names are just for debugging, stuff like "libVkICD_mock_icd" and "libVkLayer_khronos_validation".
-	[[ "${path}" == libVk* ]] && continue
-	cp -rv "${path}" /app/chromium || true
-done
-popd
+TOPLEVEL_FILES=(
+	chrome
+	chrome_100_percent.pak
+	chrome_200_percent.pak
+	chrome_crashpad_handler
+	resources.pak
+	v8_context_snapshot.bin
+
+	# ANGLE
+	libEGL.so
+	libGLESv2.so
+
+	# SwiftShader ICD
+	libvk_swiftshader.so
+	libvulkan.so.1
+	vk_swiftshader_icd.json
+)
+
+cp -v "${TOPLEVEL_FILES[@]/#/out/Release/}" /app/chromium/
+install -Dvm644 -t /app/chromium/locales out/Release/locales/*.pak
 
 for size in 24 48 64 128 256; do
-	install -Dvm 644 "chrome/app/theme/chromium/product_logo_${size}.png" "/app/share/icons/hicolor/${size}x${size}/apps/io.github.ungoogled_software.ungoogled_chromium.png";
+	install -Dvm644 "chrome/app/theme/chromium/product_logo_${size}.png" "/app/share/icons/hicolor/${size}x${size}/apps/io.github.ungoogled_software.ungoogled_chromium.png"
 done
-install -Dvm 644 chrome/app/theme/chromium/product_logo.svg /app/share/icons/hicolor/scalable/apps/io.github.ungoogled_software.ungoogled_chromium.svg
-install -Dvm 644 cobalt.ini -t /app/etc
-install -Dvm 644 io.github.ungoogled_software.ungoogled_chromium.desktop -t /app/share/applications
-install -Dvm 644 io.github.ungoogled_software.ungoogled_chromium.metainfo.xml -t /app/share/metainfo
-install -Dvm 755 chromium.sh /app/bin/chromium
+
+for size in 16 32; do
+	install -Dvm644 "chrome/app/theme/default_100_percent/chromium/product_logo_${size}.png" "/app/share/icons/hicolor/${size}x${size}/apps/io.github.ungoogled_software.ungoogled_chromium.png"
+done
+
+install -Dvm644 chrome/app/theme/chromium/product_logo.svg /app/share/icons/hicolor/scalable/apps/io.github.ungoogled_software.ungoogled_chromium.svg
+install -Dvm644 cobalt.ini -t /app/etc
+install -Dvm644 io.github.ungoogled_software.ungoogled_chromium.desktop -t /app/share/applications
+install -Dvm644 io.github.ungoogled_software.ungoogled_chromium.metainfo.xml -t /app/share/metainfo
+install -Dvm755 chromium.sh /app/bin/chromium

--- a/build-aux/install.sh
+++ b/build-aux/install.sh
@@ -22,7 +22,12 @@ TOPLEVEL_FILES=(
 )
 
 cp -v "${TOPLEVEL_FILES[@]/#/out/Release/}" /app/chromium/
+
 install -Dvm644 -t /app/chromium/locales out/Release/locales/*.pak
+for pak_file in /app/chromium/locales/*.pak; do
+	gzip -9n "${pak_file}"
+	mv "${pak_file}.gz" "${pak_file}"
+done
 
 for size in 24 48 64 128 256; do
 	install -Dvm644 "chrome/app/theme/chromium/product_logo_${size}.png" "/app/share/icons/hicolor/${size}x${size}/apps/io.github.ungoogled_software.ungoogled_chromium.png"


### PR DESCRIPTION
This is essentially what goes on with ChromeOS:

https://source.chromium.org/chromium/chromium/src/+/main:chrome/chrome_repack_locales.gni;l=101;drc=1af2ec5b8cda6242ebaed76f7f990127ab9978db
https://source.chromium.org/chromium/chromium/src/+/main:tools/grit/pak_util.py;l=46-49;drc=1bc05a16fa3381c5b839927709fad06080d3d8c0

While I can technically just set compress = true in the GNI
file, I prefer to avoid needing to carry an additional patch.

I see a non-negligible 52MB drop in install size as a result.