### PR TITLE
Remove information about Chromium staying in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,4 @@ reading any document about Ungoogled Chromium:
 instead.
 
 Also keep in mind that after making a change, make sure to do a `flatpak kill io.github.ungoogled_software.ungoogled_chromium`
-to ensure that Ungoogled Chromium was actually restarted. This is because by default, Chromium
-runs in the background after being started for the first time (closing the window doesn't actually
-exit Chromium, just keeps it in a sort of "standby" mode).
+to ensure that Ungoogled Chromium was actually restarted.


### PR DESCRIPTION
Chromium does not do this anymore by default, so remove it from the README.

See https://github.com/ungoogled-software/ungoogled-chromium-flatpak/issues/39#issuecomment-3538703794